### PR TITLE
Feat: 所属ルーム一覧ページを作成

### DIFF
--- a/app/controllers/apps/my_rooms_controller.rb
+++ b/app/controllers/apps/my_rooms_controller.rb
@@ -1,0 +1,5 @@
+class Apps::MyRoomsController < Apps::ApplicationController
+  def show
+    @room = current_user.joined_rooms
+  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -61,4 +61,6 @@ class Schedule < ApplicationRecord
     end
   end
 
+  # スコープ
+  scope :active, -> { where('end_time > ?', Time.current) }
 end

--- a/app/views/apps/my_rooms/show.html.haml
+++ b/app/views/apps/my_rooms/show.html.haml
@@ -1,0 +1,17 @@
+.container
+  %h2 所属ルーム
+  %p ルームを選択するか、新しいルームを作成・参加してください
+
+  %button= link_to '+ 新しいルームを作成', new_room_path
+  %button= link_to 'ルームに参加', room_join_path
+
+  .rooms
+    - @room.each do |room|
+      .room
+        %p= room.name
+        %ul
+          %li
+            %p メンバー #{room.members.count}人
+          %li
+            %p 予定 #{room.schedules.active.count}件
+        %button= link_to "入室する →", room_path(room)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   scope module: :apps do
     resource :membership, only: [:show, :create], path: 'rooms/join', as: :room_join
+    resource :my_room, only: [:show], path: 'myroom'
     resources :rooms, only: [ :show, :new, :create ] do
       resources :schedules
     end


### PR DESCRIPTION
# 概要

## 実装内容
- 所属ルーム一覧ページ

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0efa7c0e-50b6-43dd-a3d7-63c92fbbe98b" /> 

## 関連issue/PR
- close #29 