### PR TITLE
Feat: ヘッダーを作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,19 @@
+@use 'header';
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  text-decoration: none;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
 img {
   width: 80px;
   height: 100%;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,0 +1,14 @@
+// header
+
+header {
+  border-bottom: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 55px;
+
+  ul {
+    display: flex;
+    gap: 20px;
+  }
+}

--- a/app/views/apps/memberships/show.html.haml
+++ b/app/views/apps/memberships/show.html.haml
@@ -1,4 +1,3 @@
-= link_to '← 戻る', :back
 .container
   %h2 ルームに参加
 

--- a/app/views/apps/rooms/new.html.haml
+++ b/app/views/apps/rooms/new.html.haml
@@ -1,4 +1,3 @@
-= link_to '← 戻る', :back
 .container
   %h2 新しいルームを作成
 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,0 +1,14 @@
+%header
+  %div RoomSync
+
+  - if current_page?(edit_profile_path)
+    .page_back= link_to '← 戻る', profile_path
+
+  - elsif current_page?(new_room_path) || current_page?(room_join_path)
+    .page_back= link_to '← 戻る', my_room_path
+
+  - else
+    %ul
+      %li= link_to 'ルーム一覧', my_room_path
+      %li= link_to 'マイページ', profile_path
+      %li= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: 'delete'}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,6 +15,9 @@
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_importmap_tags
   %body
+    - if user_signed_in?
+      = render 'layouts/header'
+
     - if flash.present?
       .flash
         - flash.each do |key, value|

--- a/app/views/mypage/profiles/edit.html.haml
+++ b/app/views/mypage/profiles/edit.html.haml
@@ -1,4 +1,3 @@
-= link_to '← 戻る', profile_path
 .container
   %h2 プロフィール
 


### PR DESCRIPTION
# 概要

## 実装内容
- ヘッダー（サインイン時のみ表示）

| 通常表示|
|:--------|
| <img width="600" alt="image" src="https://github.com/user-attachments/assets/84d1dce7-9beb-4537-bb2b-e3b15f109577" />|

| ルーム作成・参加、プロフィール編集ページでの表示|
|:--------|
| <img width="600" alt="image" src="https://github.com/user-attachments/assets/bca78c72-435b-46a5-9c7d-df560f22717b" />|