### PR TITLE
Feat: ルームのメンバーシップのルーティングを変更

### DIFF
--- a/app/controllers/apps/memberships_controller.rb
+++ b/app/controllers/apps/memberships_controller.rb
@@ -1,5 +1,5 @@
 class Apps::MembershipsController < Apps::ApplicationController
-  def show
+  def new
     @room = Room.new
   end
 
@@ -13,12 +13,12 @@ class Apps::MembershipsController < Apps::ApplicationController
         redirect_to room_path(@room), notice: 'ルームに参加しました'
       else
         flash.now[:error] = '既にこのルームに参加しています'
-        render :show, status: :unprocessable_entity
+        render :new, status: :unprocessable_entity
       end
 
     else
       flash.now[:error] = 'ルームが見つかりませんでした'
-      render :show, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/apps/memberships/new.html.haml
+++ b/app/views/apps/memberships/new.html.haml
@@ -7,7 +7,7 @@
       %p 参加したいルーム名とルームキーを入力してください
 
     .form_container
-      = form_with(model: @room, url: room_join_path, method: 'post', local: true) do |f|
+      = form_with(model: @room, url: membership_path, method: 'post', local: true) do |f|
 
         .form_contents
           .form_item

--- a/app/views/apps/my_rooms/show.html.haml
+++ b/app/views/apps/my_rooms/show.html.haml
@@ -6,7 +6,7 @@
 
     %section.room_button_section
       = link_to '+ 新しいルームを作成', new_room_path, class: 'new_room_button'
-      = link_to '🔑 ルームに参加', room_join_path, class: 'join_room_button'
+      = link_to '🔑 ルームに参加', new_membership_path, class: 'join_room_button'
 
 
     %section.room_section
@@ -29,4 +29,4 @@
 
     %section.room_button_section
       = link_to '+ 新しいルームを作成', new_room_path, class: 'new_room_button'
-      = link_to '🔑 ルームに参加', room_join_path, class: 'join_room_button'
+      = link_to '🔑 ルームに参加', new_membership_path, class: 'join_room_button'

--- a/app/views/common/_room_tab.html.haml
+++ b/app/views/common/_room_tab.html.haml
@@ -4,5 +4,5 @@
       %li.form_tab_item{class: "#{add_active_class_2('rooms', ['new', 'create'])}"}
         = link_to 'ルームを作成', new_room_path
 
-      %li.form_tab_item{class: "#{add_active_class_2('memberships', ['show', 'create'])}"}
-        = link_to 'ルームに参加', room_join_path
+      %li.form_tab_item{class: "#{add_active_class_2('memberships', ['new', 'create'])}"}
+        = link_to 'ルームに参加', new_membership_path

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -15,7 +15,7 @@
     - if controller_action?('profiles', ['edit', 'update'])
       = link_to '← 戻る', profile_path, class: 'page_back'
 
-    - elsif controller_action?('rooms', ['new', 'create']) || controller_action?('memberships', ['show', 'create'])
+    - elsif controller_action?('rooms', ['new', 'create']) || controller_action?('memberships', ['new', 'create'])
       = link_to '← 戻る', my_room_path, class: 'page_back'
 
     - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Rails.application.routes.draw do
   root to: 'home#show'
 
   scope module: :apps do
-    resource :membership, only: [:show, :create], path: 'rooms/join', as: :room_join
+
+    scope :rooms do
+      resource :membership, only: [:new, :create]
+    end
+
     resource :my_room, only: [:show], path: 'myroom'
     resources :rooms, only: [ :show, :new, :create ] do
 


### PR DESCRIPTION
# 概要

## 実装内容
- ルームのメンバーシップのルーティングを変更
  - ルーム参加ページの対象アクションをshow→newに変更
 
**ルーム参加ページ**
|変更前|変更後|
|:---|:---|
|rooms/join|rooms/membership/new|

変更前
```ruby
resource :membership, only: [:show, :create], path: 'rooms/join', as: :room_join
```
変更後
```ruby
scope :rooms do
  resource :membership, only: [:new, :create]
end
```

## なぜこの変更をするのか
- ルーム参加フォームはRoomUserモデルの新しいレコードを作成するためのフォームの為、showアクションよりもnewアクションの方が適切と感じたため。また、アクションの変更に伴いパスも`rooms/join/new`とするよりも`rooms/membership/new`の方が分かりやすいと感じたため。

## 関連issue/PR
- #41 