### PR TITLE
Fix: 日数と同じ日が"今日の学習予定"と表示される問題を修正

### DIFF
--- a/app/views/simple_calendar/_calendar.html.haml
+++ b/app/views/simple_calendar/_calendar.html.haml
@@ -2,7 +2,7 @@
   .calendar-heading
     %h3.calendar-title
       .day_calendar_accent
-      %span= start_date.day == Time.current.day ? '今日の学習予定' : "#{l(start_date, format: :short)}の学習予定"
+      %span= start_date == Time.zone.today ? '今日の学習予定' : "#{l(start_date, format: :short)}の学習予定"
 
   %table.table.table-striped
     %tbody


### PR DESCRIPTION
# 概要

## 修正内容
- 日数と同じ日が"今日の学習予定"と表示される問題を修正

### 発生した事象
例）今日が3/21の場合、ピックアップした日のタイトルが、他の月の21日でも「今日の学習予定」と表示されてしまっていた

|修正前|修正後|
|---|---|
|<img width="300" alt="スクリーンショット 2026-03-21 231641" src="https://github.com/user-attachments/assets/9b93411c-d289-4536-9ebe-d5edf40a3fe0" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/43d8b348-e4c3-4f9f-bca7-228ca2e8ac61" />|

## 関連issue/PR
- close #66 