### PR TITLE
Feat: プロフィールの未入力のコンテンツを非表示にした

### DIFF
--- a/app/assets/stylesheets/pages/my_page.scss
+++ b/app/assets/stylesheets/pages/my_page.scss
@@ -86,6 +86,7 @@
   }
 
   &_sns_logo {
+    margin-left: auto;
     margin-right: 10px;
     display: flex;
     justify-content: start;

--- a/app/views/common/_mypage.html.haml
+++ b/app/views/common/_mypage.html.haml
@@ -8,16 +8,20 @@
         .profile_name= profile.name
         .profile_course= I18n.t("enum.courses.#{profile.course}")
 
-    .profile_contents_2
-      .profile_comment
-        %p= "🗨️ #{profile.comment}"
-      .profile_sns_logo
-        .sns_logo.x_logo
-          = link_to profile.x_url, target: '_blank' do
-            = image_tag 'x_logo.svg'
-        .sns_logo.github_logo
-          = link_to profile.github_url, target: '_blank' do
-            = image_tag 'github_logo.svg'
+    - if profile.comment.present? || profile.x_url.present? || profile.github_url.present?
+      .profile_contents_2
+        - if profile.comment.present?
+          .profile_comment
+            %p= "🗨️ #{profile.comment}"
+        .profile_sns_logo
+          - if profile.x_url.present?
+            .sns_logo.x_logo
+              = link_to profile.x_url, target: '_blank' do
+                = image_tag 'x_logo.svg'
+          - if profile.github_url.present?
+            .sns_logo.github_logo
+              = link_to profile.github_url, target: '_blank' do
+                = image_tag 'github_logo.svg'
 
     .profile_introduction
       .label 自己紹介


### PR DESCRIPTION
# 概要

## 実装内容
- プロフィールの未入力のコンテンツを非表示にした

### なぜこの変更をするのか
- プロフィールの項目が未入力のとき、空のつぶやきやリンクのないSNSのロゴが表示されていたため

|変更前|
|---|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/b26d385b-060d-42f1-a323-c911ce8baf91" />|

|変更後|
|---|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/8f780035-de7c-4380-93e1-212ba2fb8c0c" />|


## 関連issue/PR
- close #70 