### PR TITLE
Fix: フォームの送信ボタンのカーソルがポインターになるように修正

### DIFF
--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -154,4 +154,5 @@
 .form_button {
   @include mix.button_primary;
   width: 180px;
+  cursor: pointer;
 }


### PR DESCRIPTION
# 概要

## 実装内容
- フォームの送信ボタンのカーソルがポインターになるように修正

## なぜこの変更をするのか
- ポインターが変化しない状態だったため

## 関連issue/PR
- #99 