### PR TITLE
fix: 予定の削除後のリダイレクトパスを修正

### DIFF
--- a/app/controllers/apps/in_rooms/schedules_controller.rb
+++ b/app/controllers/apps/in_rooms/schedules_controller.rb
@@ -34,7 +34,7 @@ class Apps::InRooms::SchedulesController < Apps::InRooms::ApplicationController
   def destroy
     schedule = current_user.created_schedules.find(params[:id])
     schedule.destroy!
-    redirect_to room_path(format: :html, id:@room), notice: '予定を削除しました'
+    redirect_to room_path(format: :html, id:@room, about: Time.current.strftime('%Y-%m-%d')), notice: '予定を削除しました'
   end
 
   private


### PR DESCRIPTION
# 概要

## 実装内容
- 予定の削除後のリダイレクトパスを修正（`about: Time.current.strftime('%Y-%m-%d')`を追加）

## なぜこの変更をするのか
- 予定の削除後のリダイレクトパスにaboutの指定がないことが原因で、500エラーが生じていたため。