### PR TITLE
Fix: params[:about]が存在しない場合に今日の日付をピックアップするよう修正

### DIFF
--- a/app/controllers/apps/rooms_controller.rb
+++ b/app/controllers/apps/rooms_controller.rb
@@ -4,7 +4,7 @@ class Apps::RoomsController < Apps::ApplicationController
   def show
     @schedules = @room.schedules
 
-    pickup_date = Date.parse( params[:about] )
+    pickup_date = params[:about].present? ? Date.parse( params[:about] ) : Time.zone.today
     @pickup_schedules = @schedules.where(start_time: pickup_date.all_day)
                                   .includes(
                                     creator: { profile: { avatar_attachment: :blob } },


### PR DESCRIPTION
# 概要

## 実装内容
- params[:about]が存在しない場合に今日の日付をピックアップするよう修正

## なぜこの変更をするのか
- room_pathアクセス時、aboutを指定していない場合にエラーが発生してしまう為、aboutの指定がない場合は今日の日付をピックアップするように変更した